### PR TITLE
Small bug fixes

### DIFF
--- a/retro_pytorch/training.py
+++ b/retro_pytorch/training.py
@@ -190,6 +190,7 @@ class TrainingWrapper(nn.Module):
     def generate(
         self,
         start = None,
+        retrieved = None,
         filter_fn = top_k,
         filter_thres = 0.9,
         temperature = 1.0,

--- a/retro_pytorch/training.py
+++ b/retro_pytorch/training.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import torch
 from torch import nn
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from retro_pytorch import RETRO, RETRODataset

--- a/retro_pytorch/training.py
+++ b/retro_pytorch/training.py
@@ -128,6 +128,7 @@ class TrainingWrapper(nn.Module):
         doc_ids_memmap_path = './train.doc_ids.dat',
         max_chunks = 1_000_000,
         max_seqs = 100_000,
+        max_docs = 10_000,
         knn_extra_neighbors = 100,
         **index_kwargs
     ):
@@ -144,7 +145,8 @@ class TrainingWrapper(nn.Module):
             chunk_size = chunk_size,
             seq_len = retro.seq_len,
             max_chunks = max_chunks,
-            max_seqs = max_seqs
+            max_seqs = max_seqs,
+            max_docs = max_docs
         )
 
         num_chunks = self.stats['chunks']


### PR DESCRIPTION
See commit history for bug details, but summary is:

* Fix "referenced before assignment" bug in `TrainingWrapper.generate`
* added `max_docs` kwarg to `TrainingWrapper` constructor, needed to avoid "ValueError: could not broadcast input array..." in `text_folder_to_chunks_`
* Fix "NameError: name 'F' is not defined" in `training.py`

Link to working notebook here: https://colab.research.google.com/drive/16qgHVJZZwENckeK-PpaZrnU-QlHmVFT1

I've also submitted a PR for `autofaiss` to fix a bug that was causing issues: https://github.com/criteo/autofaiss/pull/50