### PR TITLE
[Critical] Change search metric type to l2

### DIFF
--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -289,6 +289,7 @@ def index_embeddings(
         embeddings = str(embeddings_path),
         index_path = str(index_path),
         index_infos_path = str(INDEX_FOLDER_PATH / index_infos_file),
+        metric_type = "l2",
         max_index_memory_usage = max_index_memory_usage,
         current_memory_available = current_memory_available,
         should_be_memory_mappable = True,


### PR DESCRIPTION
Hi, thank you very much for implementing and open-sourcing RETRO.
I changed the metric type used to search the index from the [inner product](https://github.com/criteo/autofaiss/blob/c4481b984758366df7e19819fbc64ebb07028776/autofaiss/utils/cast.py#L61) (`ip`, [default option of `autofaiss.build_index`](https://github.com/criteo/autofaiss/blob/c4481b984758366df7e19819fbc64ebb07028776/autofaiss/external/quantize.py#L69)) to L2 distance (`l2`).

- The [original paper](https://arxiv.org/abs/2112.04426) states that L2 distance is used as the metric.
- [This code](https://github.com/lucidrains/RETRO-pytorch/blob/81df1230cea0d0294a2981ed7a47d906c3450a7d/retro_pytorch/retrieval.py#L393) is written with the assumption that the top-1 retrieved item would be the query itself. However, if the inner product (not cosine similarity) is used as the metric, there is a possibility that the top-1 item might not be the query itself. Therefore, the code might not properly remove the query from the retrieved neighbors. (e.g., If `q = [1, 0, 0]` and `u = [2, 0, 0]`, then `qᵀq = 1 < qᵀu = 2`)
- Still, the code in its current form does not break the causality because the [next code](https://github.com/lucidrains/RETRO-pytorch/blob/81df1230cea0d0294a2981ed7a47d906c3450a7d/retro_pytorch/retrieval.py#L403) masks out the neighbors that belong to the same document. However...
- This metric bug must have been **critical** because [this code](https://github.com/lucidrains/RETRO-pytorch/blob/81df1230cea0d0294a2981ed7a47d906c3450a7d/retro_pytorch/retrieval.py#L407) assumes that the distances were computed using l2, and thus uses **ascending order sort** to retrieve the items with the smallest distances as the nearest neighbors. However, since the [current code](https://github.com/lucidrains/RETRO-pytorch/blob/81df1230cea0d0294a2981ed7a47d906c3450a7d/retro_pytorch/retrieval.py#L288) uses the inner product to calculate the distance as described above, [this code](https://github.com/lucidrains/RETRO-pytorch/blob/81df1230cea0d0294a2981ed7a47d906c3450a7d/retro_pytorch/retrieval.py#L407) has been selecting **the most irrelevant sequences** as the neighbors to attend to.