### PR TITLE
Update retrieval.py

### DIFF
--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -266,7 +266,7 @@ def memmap_file_to_chunks_(
         reset_folder_(root_path)
 
         for ind, dim_slice in enumerate(range_chunked(rows, batch_size = max_rows_per_file)):
-            filename = root_path / f'{ind}.npy'
+            filename = root_path / f'{ind:05d}.npy'
             data_slice = f[dim_slice]
 
             np.save(str(filename), f[dim_slice])


### PR DESCRIPTION
[The build_index command](https://criteo.github.io/autofaiss/getting_started/quantization.html#the-build-index-command)

In the autofaiss document "–embeddings" Description : "Source path of the directory containing your .npy embedding files. If there are several files, **they are read in the lexicographical order**. This can be a local path or a path in another Filesystem e.g. hdfs://root/… or s3://…"

The build_index function read embedding folders in lexicographical order, but now saves embedding files in order of "0.npy, 1.npy, 2.npy,..., n.npy", then build_index read embeddings in order of "0.npy, 1.npy, 10.npy......., 2.npy,..., n.npy", So I fill in some zeros in front of the embedding file name to make the build_index work normal.