### PR TITLE
Fix reconstruction error discussed in #15

### DIFF
--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -292,7 +292,8 @@ def index_embeddings(
         metric_type = "l2",
         max_index_memory_usage = max_index_memory_usage,
         current_memory_available = current_memory_available,
-        should_be_memory_mappable = True,
+        make_direct_map = True
+        should_be_memory_mappable = False,
         use_gpu = torch.cuda.is_available(),
     )
 


### PR DESCRIPTION
This PR fixes the issue with reconstruction of the faiss index. One caveat is that we can no longer do memmapping to reduce RAM overhead. Maybe this will be fixed in faiss soon, but for now memory will be an issue for extremely large indices.