### PR TITLE
Various Scale Things

### DIFF
--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -189,6 +189,7 @@ def bert_embed(
 
     if torch.cuda.is_available():
         token_ids = token_ids.cuda()
+        mask = mask.cuda()
 
     outputs = model(
         input_ids = token_ids,

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -340,6 +340,11 @@ def index_embeddings(
     print(f'Training...')
     # Apparently FAISS plays nice with numpy memmap. 
     index.train(train_embeds)
+
+    # Save the index immediately after training (which takes a long
+    # time) in case we fail for some reason to add the embeds to the index.
+    faiss.write_index(index, str(index_path) + '.trained')
+
     print(f'Adding embeds to index...')
     # Do it in chunks so we don't run out of RAM
     for dim_slice in range_chunked(embeddings.shape[0], batch_size=128):

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -360,10 +360,15 @@ def index_embeddings(
 
     print(f'Adding embeds to index...')
     # Do it in chunks so we don't run out of RAM. For 5.8 B embeddings
-    # and 4 threads, this took around 1.2 days.
+    # and 4 threads, this took around 2 days.
+    last_billion = 0
     for dim_slice in range_chunked(embeddings.shape[0], batch_size=128):
         if dim_slice.start % (128 * 1000) == 0:
             print(dim_slice.start)
+            if dim_slice.start // 1_000_000_000 > last_billion:
+                last_billion += 1
+                print(f'Writing index to {index_path} ({last_billion} billion)...')
+                faiss.write_index(index, str(index_path))
         index.add(embeddings[dim_slice])
 
     print(f'Writing index to {index_path}...')

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -21,7 +21,6 @@ BERT_MODEL_DIM = 768
 BERT_VOCAB_SIZE = 28996
 
 TMP_PATH = Path('./.tmp')
-INDEX_FOLDER_PATH = TMP_PATH / '.index'
 EMBEDDING_TMP_SUBFOLDER = 'embeddings'
 
 # helper functions
@@ -293,11 +292,8 @@ def chunks_to_embeddings_(
 def index_embeddings(
     embeddings_path,
     embed_shape,
-    *,
-    index_file = 'knn.index',
+    index_path = 'knn.index',
 ):
-    index_path = INDEX_FOLDER_PATH / index_file
-    reset_folder_(INDEX_FOLDER_PATH)
     embeddings = BertEmbeds(fname = embeddings_path, shape = embed_shape, dtype = np.float32, mode = 'r')
 
     # Per https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
@@ -396,17 +392,16 @@ def chunks_to_precalculated_knn_(
     chunk_size,
     chunk_memmap_path,
     doc_ids_memmap_path,
+    index_path,
     use_cls_repr = False,
     max_rows_per_file = 500,
     chunks_to_embeddings_batch_size = 16,
     embed_dim = BERT_MODEL_DIM,
     num_extra_neighbors = 10,
     force_reprocess = False,
-    index_file = 'knn.index',
 ):
     chunk_path = Path(chunk_memmap_path)
     knn_path = chunk_path.parents[0] / f'{chunk_path.stem}.knn{chunk_path.suffix}'
-    index_path = INDEX_FOLDER_PATH / index_file
 
     # early return knn path and faiss index
     # unless if force_reprocess is True

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -180,6 +180,10 @@ def _text_to_chunks(
             doc_chunk_len = chunks.shape[0]
             doc_seq_len = seq.shape[0]
 
+            if doc_chunk_len > max_chunks - total_chunks or doc_seq_len > max_seqs - total_seqs:
+                print(f'Hit max seqs / chunks, stopping')
+                break
+
             chunks_memmap[total_chunks:(total_chunks + doc_chunk_len)] = chunks.numpy()
             seqs_memmap[total_seqs:(total_seqs + doc_seq_len)] = seq.numpy() + total_chunks
             doc_ids_memmap[total_chunks:(total_chunks + doc_chunk_len)] = np.full((doc_chunk_len,), total_docs)

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -188,6 +188,9 @@ def _text_to_chunks(
             total_seqs += doc_seq_len
             total_docs += 1
 
+            if total_docs % 1000 == 0:
+                print(f'Processed {total_docs} docs')
+
     return dict(
         chunks = total_chunks,
         docs = total_docs,

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -307,7 +307,7 @@ def train_faiss_index(embeddings, index_path):
     # Note that the IndexIVFPQFastScan index created by this factory is intended for use on AVX2 enabled CPUs.
     # Also note that this index requires *at least* ~16x4 bits of RAM for every stored vector.
     # That's around 43 GB for 5.8B vectors.
-    index = faiss.index_factory(BERT_MODEL_DIM, f'OPQ4_64,IVF{num_clusters}_HNSW32,PQ16x4fs')
+    index = faiss.index_factory(BERT_MODEL_DIM, f'OPQ16,IVF{num_clusters}_HNSW32,PQ16x4fs')
 
     # From https://gist.github.com/mdouze/46d6bbbaabca0b9778fca37ed2bcccf6
     # For a sense of the speedup you get from using GPUs:

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -306,7 +306,8 @@ def train_faiss_index(embeddings, index_path):
     # See https://github.com/facebookresearch/faiss/wiki/The-index-factory for what this string means.
     # Note that the IndexIVFPQFastScan index created by this factory is intended for use on AVX2 enabled CPUs.
     # Also note that this index requires *at least* ~16x4 bits of RAM for every stored vector.
-    # That's around 43 GB for 5.8B vectors.
+    # That's around 43 GB for 5.8B vectors. There are other overheads for each vector as well, including 
+    # an 8 byte vector id. In practice, the 5.8B vector index was around 176 GB in RAM.
     index = faiss.index_factory(BERT_MODEL_DIM, f'OPQ16_64,IVF{num_clusters}_HNSW32,PQ16x4fs')
 
     # From https://gist.github.com/mdouze/46d6bbbaabca0b9778fca37ed2bcccf6

--- a/retro_pytorch/retrieval.py
+++ b/retro_pytorch/retrieval.py
@@ -307,7 +307,7 @@ def train_faiss_index(embeddings, index_path):
     # Note that the IndexIVFPQFastScan index created by this factory is intended for use on AVX2 enabled CPUs.
     # Also note that this index requires *at least* ~16x4 bits of RAM for every stored vector.
     # That's around 43 GB for 5.8B vectors.
-    index = faiss.index_factory(BERT_MODEL_DIM, f'OPQ16,IVF{num_clusters}_HNSW32,PQ16x4fs')
+    index = faiss.index_factory(BERT_MODEL_DIM, f'OPQ16_64,IVF{num_clusters}_HNSW32,PQ16x4fs')
 
     # From https://gist.github.com/mdouze/46d6bbbaabca0b9778fca37ed2bcccf6
     # For a sense of the speedup you get from using GPUs:

--- a/retro_pytorch/utils.py
+++ b/retro_pytorch/utils.py
@@ -97,3 +97,11 @@ class BertEmbeds:
             else:
                 self.part1[key.start:self.max_rows_per_file] = val[:self.max_rows_per_file - key.start]
                 self.part2[:key.stop - self.max_rows_per_file] = val[self.max_rows_per_file - key.start:]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        del self.part1
+        if hasattr(self, 'part2'):
+            del self.part2

--- a/retro_pytorch/utils.py
+++ b/retro_pytorch/utils.py
@@ -2,6 +2,8 @@ import os
 import numpy as np
 
 from pathlib import Path
+from functools import reduce
+import math
 from shutil import rmtree
 from contextlib import contextmanager
 
@@ -18,3 +20,80 @@ def memmap(*args, **kwargs):
     pointer = np.memmap(*args, **kwargs)
     yield pointer
     del pointer
+
+
+def check_key(key):
+    if isinstance(key, tuple):
+        raise NotImplementedError("BertEmbeds don't support tuple indexing") 
+    if isinstance(key, slice):
+        if key.step:
+            raise NotImplementedError("BertEmbeds don't support slice steps")
+        if key.start < 0 or key.stop < 0:
+            raise NotImplementedError("BertEmbeds don't support negative slices")
+
+class BertEmbeds:
+    """This class exists solely to workaround the max filesize on ext4
+    (16 TB) by pretending to be a single numpy memmap'd array when in
+    fact it is two (10TB) split files. If you're here with a file
+    bigger than 20 TB, sorry."""
+
+    def __init__(self, fname, dtype, shape, mode):
+        elems_per_row =  reduce(lambda acc, x: x * acc, shape[1:])
+        bytes_per_row = dtype(0).nbytes * elems_per_row
+        print(f'Bytes per row: {bytes_per_row}')
+        ten_TB = 1024**4 * 10 
+
+        # We only split when we have more than ten TB of data
+        total_bytes = bytes_per_row * shape[0]
+        print(f'Total bytes: {total_bytes}')
+        self.num_files = math.ceil(total_bytes / ten_TB)
+        if self.num_files > 2:
+            raise NotImplementedError("BertEmbeds doesn't support files > 20 TB")
+
+        # Each file should have around 10 TB of data. We explicitly do
+        # this instead of dividing the rows evenly between files to
+        # handle the case when a user constructs this class with a
+        # shape other than the original number of rows.
+        self.max_rows_per_file = ten_TB // bytes_per_row
+
+        part1_num_rows = shape[0] if self.num_files == 1 else self.max_rows_per_file
+        part2_num_rows = shape[0] - self.max_rows_per_file
+        self.part1 = np.memmap(fname + '.part1', dtype=dtype, shape=(part1_num_rows, *shape[1:]), mode=mode)
+        if part2_num_rows > 0:
+            self.part2 = np.memmap(fname + '.part2', dtype=dtype, shape=(part2_num_rows, *shape[1:]), mode=mode)
+
+        self.shape = shape
+        self.dtype = dtype
+
+    def __getitem__(self, key):
+        check_key(key)
+        if isinstance(key, int):
+            if key < self.max_rows_per_file:
+                return self.part1[key]
+            else:
+                return self.part2[key - self.max_rows_per_file]
+
+        if isinstance(key, slice):
+            if key.stop < self.max_rows_per_file:
+                return self.part1[key] 
+            elif key.start >= self.max_rows_per_file:
+                return self.part2[key.start - self.max_rows_per_file: key.stop - self.max_rows_per_file]
+            else:
+                return np.concatenate((self.part1[key.start:self.max_rows_per_file], self.part2[:key.stop - self.max_rows_per_file]))
+
+    def __setitem__(self, key, val):
+        check_key(key)
+        if isinstance(key, int):
+            if key < self.max_rows_per_file:
+                self.part1[key] = val
+            else:
+                self.part2[key - self.max_rows_per_file] = val
+
+        if isinstance(key, slice):
+            if key.stop < self.max_rows_per_file:
+                self.part1[key] = val
+            elif key.start >= self.max_rows_per_file:
+                self.part2[key.start - self.max_rows_per_file : key.stop - self.max_rows_per_file] = val
+            else:
+                self.part1[key.start:self.max_rows_per_file] = val[:self.max_rows_per_file - key.start]
+                self.part2[:key.stop - self.max_rows_per_file] = val[self.max_rows_per_file - key.start:]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     'retrieval',
   ],
   install_requires=[
+    'transformers',
     'autofaiss',
     'einops>=0.3',
     'numpy',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
   ],
   install_requires=[
     'transformers',
-    'autofaiss',
     'einops>=0.3',
     'numpy',
     'sentencepiece',


### PR DESCRIPTION
Hey Lucid,

I've been working on scaling the DB up to contain the whole Pile in my free time. En route to this, I've made a few changes that you might be interested in merging:

- Ditch autofaiss in favor of manually constructing the FAISS index to be as close to SCANN as possible
- Add support for training the index on GPUs
- Parallelize `chunks_to_embeddings_` by adding a "worker_id" param
- `chunks_to_precalculated_knn_` should be able to reuse pre-computed embeds etc.
- Add a `BertEmbeds` class that supports memmap'd files > 16 TB (max file size on ext4)
- Add support for going from jsonl->chunks (which is what the Pile is) in addition to txt->chunks (just for convenience)

Index creation at scale isn't really tested (but I have tested it at smaller scales). I'm running embedding at scale right now and I *think* it works. Anyway, I don't really expect you to just merge this but figured I'd mention it before I get too far off master.